### PR TITLE
Limit size of previews to max that the Camera2 API supports

### DIFF
--- a/library/src/main/base/com/google/android/cameraview/SizeMap.java
+++ b/library/src/main/base/com/google/android/cameraview/SizeMap.java
@@ -54,16 +54,24 @@ class SizeMap {
         return true;
     }
 
-    public Set<AspectRatio> ratios() {
+    /**
+     * Removes the specified aspect ratio and all sizes associated with it.
+     *
+     * @param ratio The aspect ratio to be removed.
+     */
+    public void remove(AspectRatio ratio) {
+        mRatios.remove(ratio);
+    }
+
+    Set<AspectRatio> ratios() {
         return mRatios.keySet();
     }
 
-    public SortedSet<Size> sizes(AspectRatio ratio) {
+    SortedSet<Size> sizes(AspectRatio ratio) {
         return mRatios.get(ratio);
     }
 
-    public void clear() {
+    void clear() {
         mRatios.clear();
     }
-
 }


### PR DESCRIPTION
Updated the code which takes previews to match `google/cameraview` - now it filters out previews which are larger than the max the Camera2 API supports. On the LG G4, the preview was 5312 by 2988!

Tested on the LG G4, G4 Stylus, S6, S7, Acer and S5 mini