### PR TITLE
Fix focus issues, ratio issues and better support video mode

### DIFF
--- a/library/src/androidTest/java/com/google/android/cameraview/CameraViewActivity.java
+++ b/library/src/androidTest/java/com/google/android/cameraview/CameraViewActivity.java
@@ -35,7 +35,7 @@ public class CameraViewActivity extends Activity {
     @Override
     protected void onResume() {
         super.onResume();
-        mCameraView.start();
+        mCameraView.startPictureMode();
     }
 
     @Override

--- a/library/src/androidTest/java/com/google/android/cameraview/CameraViewTest.java
+++ b/library/src/androidTest/java/com/google/android/cameraview/CameraViewTest.java
@@ -123,7 +123,8 @@ public class CameraViewTest {
                             }
                         }
                         assert ratio != null;
-                        cameraView.setAspectRatio(ratio);
+                        AspectRatio[] preferredRatios = {ratio};
+                        cameraView.setPreferredAspectRatio(preferredRatios);
                         assertThat(cameraView.getAspectRatio(), is(equalTo(ratio)));
                     }
                 });

--- a/library/src/main/base/com/google/android/cameraview/AspectRatio.java
+++ b/library/src/main/base/com/google/android/cameraview/AspectRatio.java
@@ -16,6 +16,7 @@
 
 package com.google.android.cameraview;
 
+import android.content.res.Configuration;
 import android.os.Parcel;
 import android.os.Parcelable;
 import android.support.annotation.NonNull;
@@ -100,6 +101,16 @@ public class AspectRatio implements Comparable<AspectRatio>, Parcelable {
         int x = size.getWidth() / gcd;
         int y = size.getHeight() / gcd;
         return mX == x && mY == y;
+    }
+
+    public boolean matchesOrientation(int orientation) {
+        switch (orientation) {
+            case Configuration.ORIENTATION_LANDSCAPE:
+                return toFloat() >= 1;
+            case Configuration.ORIENTATION_PORTRAIT:
+                return toFloat() <= 1;
+        }
+        return false;
     }
 
     @Override

--- a/library/src/main/base/com/google/android/cameraview/CameraViewImpl.java
+++ b/library/src/main/base/com/google/android/cameraview/CameraViewImpl.java
@@ -31,7 +31,9 @@ abstract class CameraViewImpl {
 
     abstract TextureView.SurfaceTextureListener getSurfaceTextureListener();
 
-    abstract void start();
+    abstract void startPictureMode();
+
+    abstract void startVideoMode(String videoFilePath);
 
     abstract void stop();
 
@@ -78,7 +80,7 @@ abstract class CameraViewImpl {
 
     abstract void setDisplayOrientation(int displayOrientation);
 
-    abstract void startRecordingVideo(String videoFilePath);
+    abstract void startRecordingVideo();
 
     abstract void stopRecordingVideo();
 

--- a/library/src/main/base/com/google/android/cameraview/CameraViewImpl.java
+++ b/library/src/main/base/com/google/android/cameraview/CameraViewImpl.java
@@ -59,7 +59,10 @@ abstract class CameraViewImpl {
 
     abstract Set<AspectRatio> getSupportedAspectRatios();
 
-    abstract void setAspectRatio(AspectRatio ratio);
+    /**
+     * @return {@code true} if the aspect ratio was changed.
+     */
+    abstract boolean setAspectRatio(AspectRatio ratio);
 
     abstract AspectRatio getAspectRatio();
 

--- a/library/src/main/base/com/google/android/cameraview/CameraViewImpl.java
+++ b/library/src/main/base/com/google/android/cameraview/CameraViewImpl.java
@@ -33,7 +33,7 @@ abstract class CameraViewImpl {
 
     abstract void startPictureMode();
 
-    abstract void startVideoMode(String videoFilePath);
+    abstract void startVideoMode();
 
     abstract void stop();
 
@@ -64,9 +64,18 @@ abstract class CameraViewImpl {
     /**
      * @return {@code true} if the aspect ratio was changed.
      */
-    abstract boolean setAspectRatio(AspectRatio ratio);
+    abstract boolean setPreferredAspectRatios(AspectRatio[] ratios);
+
+    abstract AspectRatio[] getPreferredAspectRatios();
 
     abstract AspectRatio getAspectRatio();
+
+    /**
+     * Overall orientation of the screen. May be one of
+     * {@link android.content.res.Configuration#ORIENTATION_LANDSCAPE},
+     * {@link android.content.res.Configuration#ORIENTATION_PORTRAIT}.
+     */
+    abstract void setScreenOrientation(int screenOrientation);
 
     abstract void setAutoFocus(boolean autoFocus);
 
@@ -80,7 +89,7 @@ abstract class CameraViewImpl {
 
     abstract void setDisplayOrientation(int displayOrientation);
 
-    abstract void startRecordingVideo();
+    abstract void startRecordingVideo(String videoFilePath);
 
     abstract void stopRecordingVideo();
 

--- a/library/src/main/base/com/google/android/cameraview/Constants.java
+++ b/library/src/main/base/com/google/android/cameraview/Constants.java
@@ -16,11 +16,7 @@
 
 package com.google.android.cameraview;
 
-
 interface Constants {
-
-    AspectRatio DEFAULT_ASPECT_RATIO = AspectRatio.of(4, 3);
-
     int FACING_BACK = 0;
     int FACING_FRONT = 1;
 
@@ -29,5 +25,4 @@ interface Constants {
     int FLASH_TORCH = 2;
     int FLASH_AUTO = 3;
     int FLASH_RED_EYE = 4;
-
 }

--- a/library/src/main/base/com/google/android/cameraview/Size.java
+++ b/library/src/main/base/com/google/android/cameraview/Size.java
@@ -45,6 +45,11 @@ public class Size implements Comparable<Size> {
         return mHeight;
     }
 
+    public long getArea() {
+        // We cast here to ensure the multiplications won't overflow
+        return (long) mWidth * mHeight;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (o == null) {

--- a/library/src/main/base/com/google/android/cameraview/SizeMap.java
+++ b/library/src/main/base/com/google/android/cameraview/SizeMap.java
@@ -17,7 +17,10 @@
 package com.google.android.cameraview;
 
 import android.support.v4.util.ArrayMap;
+import android.support.v4.util.ArraySet;
 
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
@@ -71,7 +74,26 @@ class SizeMap {
         return mRatios.get(ratio);
     }
 
+    Size largest() {
+        Set<Size> allSizes = new ArraySet<>();
+        for (SortedSet<Size> sizes: mRatios.values()) {
+            allSizes.addAll(sizes);
+        }
+        return Collections.max(allSizes, new CompareSizesByArea());
+    }
+
     void clear() {
         mRatios.clear();
+    }
+
+    /**
+     * Compares two {@code Size}s based on their areas.
+     */
+    private static class CompareSizesByArea implements Comparator<Size> {
+
+        @Override
+        public int compare(Size lhs, Size rhs) {
+            return Long.signum(lhs.getArea() - rhs.getArea());
+        }
     }
 }

--- a/library/src/main/base/com/google/android/cameraview/SizeMap.java
+++ b/library/src/main/base/com/google/android/cameraview/SizeMap.java
@@ -16,6 +16,7 @@
 
 package com.google.android.cameraview;
 
+import android.support.annotation.Nullable;
 import android.support.v4.util.ArrayMap;
 import android.support.v4.util.ArraySet;
 
@@ -71,7 +72,10 @@ class SizeMap {
     }
 
     SortedSet<Size> sizes(AspectRatio ratio) {
-        return mRatios.get(ratio);
+        if (mRatios.containsKey(ratio)) {
+            return mRatios.get(ratio);
+        }
+        return new TreeSet<>();
     }
 
     Size largest() {

--- a/library/src/main/base/com/google/android/cameraview/SizeMap.java
+++ b/library/src/main/base/com/google/android/cameraview/SizeMap.java
@@ -16,6 +16,7 @@
 
 package com.google.android.cameraview;
 
+import android.content.res.Configuration;
 import android.support.annotation.Nullable;
 import android.support.v4.util.ArrayMap;
 import android.support.v4.util.ArraySet;
@@ -78,12 +79,18 @@ class SizeMap {
         return new TreeSet<>();
     }
 
-    Size largest() {
-        Set<Size> allSizes = new ArraySet<>();
-        for (SortedSet<Size> sizes: mRatios.values()) {
-            allSizes.addAll(sizes);
+    Size largest(int preferredOrientation) {
+        Set<Size> preferredSizes = new ArraySet<>();
+        Set<Size> otherSizes = new ArraySet<>();
+        for (AspectRatio ratio : mRatios.keySet()) {
+            if (ratio.matchesOrientation(preferredOrientation)) {
+                preferredSizes.addAll(mRatios.get(ratio));
+            } else {
+                otherSizes.addAll(mRatios.get(ratio));
+            }
         }
-        return Collections.max(allSizes, new CompareSizesByArea());
+
+        return Collections.max(!preferredSizes.isEmpty() ? preferredSizes : otherSizes, new CompareSizesByArea());
     }
 
     void clear() {

--- a/library/src/main/base/com/google/android/cameraview/TapFocusable.java
+++ b/library/src/main/base/com/google/android/cameraview/TapFocusable.java
@@ -1,0 +1,5 @@
+package com.google.android.cameraview;
+
+interface TapFocusable {
+    void setFocusTarget(int x, int y);
+}

--- a/library/src/main/base/com/google/android/cameraview/TapFocusable.java
+++ b/library/src/main/base/com/google/android/cameraview/TapFocusable.java
@@ -1,5 +1,0 @@
-package com.google.android.cameraview;
-
-interface TapFocusable {
-    void setFocusTarget(int x, int y);
-}

--- a/library/src/main/camera2/com/google/android/cameraview/Camera2.java
+++ b/library/src/main/camera2/com/google/android/cameraview/Camera2.java
@@ -791,9 +791,12 @@ class Camera2 extends CameraViewImpl {
         if (mAutoFocus) {
             int[] modes = mCameraCharacteristics.get(
                     CameraCharacteristics.CONTROL_AF_AVAILABLE_MODES);
+            Integer level = mCameraCharacteristics.get(
+                    CameraCharacteristics.INFO_SUPPORTED_HARDWARE_LEVEL);
             // Auto focus is not supported
-            if (modes == null || modes.length == 0 ||
-                    (modes.length == 1 && modes[0] == CameraCharacteristics.CONTROL_AF_MODE_OFF)) {
+            if (modes == null || modes.length == 0
+                    || (modes.length == 1 && modes[0] == CameraCharacteristics.CONTROL_AF_MODE_OFF)
+                    || level == null || level == CameraCharacteristics.INFO_SUPPORTED_HARDWARE_LEVEL_LEGACY) {
                 mAutoFocus = false;
                 mPreviewRequestBuilder.set(CaptureRequest.CONTROL_AF_MODE,
                         CaptureRequest.CONTROL_AF_MODE_OFF);

--- a/library/src/main/camera2/com/google/android/cameraview/Camera2.java
+++ b/library/src/main/camera2/com/google/android/cameraview/Camera2.java
@@ -407,8 +407,10 @@ class Camera2 extends CameraViewImpl {
             return false;
         }
         mAspectRatio = ratio;
+        prepareImageReader();
         if (mCaptureSession != null) {
             mCaptureSession.close();
+            mCaptureSession = null;
             startCaptureSession();
         }
         return true;
@@ -616,13 +618,16 @@ class Camera2 extends CameraViewImpl {
         }
     }
 
-    private void collectPictureSizes(StreamConfigurationMap map) {
+    protected void collectPictureSizes(StreamConfigurationMap map) {
         for (android.util.Size size : map.getOutputSizes(ImageFormat.JPEG)) {
             mPictureSizes.add(new Size(size.getWidth(), size.getHeight()));
         }
     }
 
     private void prepareImageReader() {
+        if (mImageReader != null) {
+            mImageReader.close();
+        }
         Size largest = mPictureSizes.sizes(mAspectRatio).last();
         mImageReader = ImageReader.newInstance(largest.getWidth(), largest.getHeight(),
                 ImageFormat.JPEG, /* maxImages */ 2);
@@ -651,7 +656,7 @@ class Camera2 extends CameraViewImpl {
      * <p>The result will be continuously processed in {@link #mSessionCallback}.</p>
      */
     private void startCaptureSession() {
-        if (!isCameraOpened() || mSurfaceInfo.surface == null) {
+        if (!isCameraOpened() || mSurfaceInfo.surface == null || mImageReader == null) {
             return;
         }
         Size previewSize = chooseOptimalSize();

--- a/library/src/main/camera2/com/google/android/cameraview/Camera2.java
+++ b/library/src/main/camera2/com/google/android/cameraview/Camera2.java
@@ -27,7 +27,6 @@ import android.hardware.camera2.CameraCharacteristics;
 import android.hardware.camera2.CameraDevice;
 import android.hardware.camera2.CameraManager;
 import android.hardware.camera2.CaptureRequest;
-import android.hardware.camera2.CaptureResult;
 import android.hardware.camera2.TotalCaptureResult;
 import android.hardware.camera2.params.StreamConfigurationMap;
 import android.media.Image;
@@ -78,8 +77,6 @@ class Camera2 extends CameraViewImpl {
      * Max preview height that is guaranteed by Camera2 API
      */
     private static final int MAX_PREVIEW_HEIGHT = 1080;
-
-    private static final int MAX_LOCK_FOCUS_ATTEMPTS = 3;
 
     private final CameraManager mCameraManager;
 
@@ -797,29 +794,11 @@ class Camera2 extends CameraViewImpl {
      * Updates the internal state of auto-focus to {@link #mAutoFocus}.
      */
     private void updateAutoFocus() {
-        mPreviewRequestBuilder.set(CaptureRequest.CONTROL_AF_MODE,
-                                   mAutoFocus ? pickAutoFocusMode() : CaptureRequest.CONTROL_AF_MODE_OFF);
-    }
-
-    private int pickAutoFocusMode() {
-        int[] supportedModes = mCameraCharacteristics.get(CameraCharacteristics.CONTROL_AF_AVAILABLE_MODES);
-        if (arrayContains(supportedModes, CaptureRequest.CONTROL_AF_MODE_CONTINUOUS_PICTURE)) {
-            // TODO Exclude S5 and Note 3 here.
-            return CaptureRequest.CONTROL_AF_MODE_CONTINUOUS_PICTURE;
-        } else if (arrayContains(supportedModes, CaptureRequest.CONTROL_AF_MODE_AUTO)) {
-            return CaptureRequest.CONTROL_AF_MODE_AUTO;
+        int afMode = CaptureRequest.CONTROL_AF_MODE_OFF;
+        if (mAutoFocus) {
+            afMode = FocusModeSelector.getBestAfMode(mCameraCharacteristics);
         }
-        return CaptureRequest.CONTROL_AF_MODE_OFF;
-    }
-
-    private boolean arrayContains(int[] array, int value) {
-        if (array == null) return false;
-        for (int i = 0; i < array.length; i++) {
-            if (array[i] == value) {
-                return true;
-            }
-        }
-        return false;
+        mPreviewRequestBuilder.set(CaptureRequest.CONTROL_AF_MODE, afMode);
     }
 
     /**
@@ -954,104 +933,6 @@ class Camera2 extends CameraViewImpl {
         } catch (CameraAccessException e) {
             Log.e(TAG, "Failed to restart camera preview.", e);
         }
-    }
-
-    /**
-     * A {@link CameraCaptureSession.CaptureCallback} for capturing a still picture.
-     */
-    private static abstract class PictureCaptureCallback
-            extends CameraCaptureSession.CaptureCallback {
-
-        public static final int STATE_PREVIEW = 0;
-        public static final int STATE_LOCKING = 1;
-        public static final int STATE_LOCKED = 2;
-        public static final int STATE_PRECAPTURE = 3;
-        public static final int STATE_WAITING = 4;
-        public static final int STATE_CAPTURING = 5;
-
-        private int mState;
-        private int mLockFocusAttemptsCount;
-
-
-        public void setState(int state) {
-            mState = state;
-        }
-
-        void clearLockFocusAttemptsCount() {
-            mLockFocusAttemptsCount = 0;
-        }
-
-        @Override
-        public void onCaptureProgressed(@NonNull CameraCaptureSession session,
-                                        @NonNull CaptureRequest request,
-                                        @NonNull CaptureResult partialResult) {
-            process(partialResult);
-        }
-
-        @Override
-        public void onCaptureCompleted(@NonNull CameraCaptureSession session,
-                                       @NonNull CaptureRequest request,
-                                       @NonNull TotalCaptureResult result) {
-            process(result);
-        }
-
-        private void process(@NonNull CaptureResult result) {
-            switch (mState) {
-                case STATE_LOCKING: {
-                    Integer af = result.get(CaptureResult.CONTROL_AF_STATE);
-                    if (af == null) {
-                        break;
-                    }
-                    Integer ae = result.get(CaptureResult.CONTROL_AE_STATE);
-                    boolean focused = af == CaptureResult.CONTROL_AF_STATE_FOCUSED_LOCKED;
-                    boolean notFocused = af == CaptureResult.CONTROL_AF_STATE_NOT_FOCUSED_LOCKED;
-                    if (focused || (notFocused && mLockFocusAttemptsCount >= MAX_LOCK_FOCUS_ATTEMPTS)) {
-                        if (ae == null || ae == CaptureResult.CONTROL_AE_STATE_CONVERGED) {
-                            setState(STATE_CAPTURING);
-                            onReady();
-                        } else {
-                            setState(STATE_LOCKED);
-                            onPrecaptureRequired();
-                        }
-                    } else if (notFocused) {
-                        onLockFocusRetryRequired();
-                        mLockFocusAttemptsCount++;
-                    }
-                    break;
-                }
-                case STATE_PRECAPTURE: {
-                    Integer ae = result.get(CaptureResult.CONTROL_AE_STATE);
-                    if (ae == null || ae == CaptureResult.CONTROL_AE_STATE_PRECAPTURE ||
-                            ae == CaptureRequest.CONTROL_AE_STATE_FLASH_REQUIRED ||
-                            ae == CaptureResult.CONTROL_AE_STATE_CONVERGED) {
-                        setState(STATE_WAITING);
-                    }
-                    break;
-                }
-                case STATE_WAITING: {
-                    Integer ae = result.get(CaptureResult.CONTROL_AE_STATE);
-                    if (ae == null || ae != CaptureResult.CONTROL_AE_STATE_PRECAPTURE) {
-                        setState(STATE_CAPTURING);
-                        onReady();
-                    }
-                    break;
-                }
-            }
-        }
-
-        /**
-         * Called when it is ready to take a still picture.
-         */
-        public abstract void onReady();
-
-        /**
-         * Called when it is necessary to run the precapture sequence.
-         */
-        public abstract void onPrecaptureRequired();
-        /**
-         * Called when locking focus has failed but MAX_LOCK_FOCUS_ATTEMPTS hasn't been reached yet
-         */
-        public abstract void onLockFocusRetryRequired();
     }
 
 }

--- a/library/src/main/camera2/com/google/android/cameraview/Camera2.java
+++ b/library/src/main/camera2/com/google/android/cameraview/Camera2.java
@@ -400,17 +400,18 @@ class Camera2 extends CameraViewImpl {
     }
 
     @Override
-    void setAspectRatio(AspectRatio ratio) {
+    boolean setAspectRatio(AspectRatio ratio) {
         if (ratio == null || ratio.equals(mAspectRatio) ||
                 !mPreviewSizes.ratios().contains(ratio)) {
             // TODO: Better error handling
-            return;
+            return false;
         }
         mAspectRatio = ratio;
         if (mCaptureSession != null) {
             mCaptureSession.close();
             startCaptureSession();
         }
+        return true;
     }
 
     @Override

--- a/library/src/main/camera2/com/google/android/cameraview/Camera2.java
+++ b/library/src/main/camera2/com/google/android/cameraview/Camera2.java
@@ -407,6 +407,11 @@ class Camera2 extends CameraViewImpl {
         mFacing = facing;
         if (isCameraOpened()) {
             stop();
+            if (mVideoMode) {
+                startVideoMode();
+            } else {
+                startPictureMode();
+            }
         }
     }
 
@@ -746,7 +751,7 @@ class Camera2 extends CameraViewImpl {
             }
             mCamera.createCaptureSession(outputs, mSessionCallback, mBackgroundHandler);
         } catch (CameraAccessException e) {
-            throw new RuntimeException("Failed to start capture session", e);
+            throw new RuntimeException("Failed to start capture session for mode " + (mVideoMode ? "video" : "picture"), e);
         }
     }
 

--- a/library/src/main/camera2/com/google/android/cameraview/FocusModeSelector.java
+++ b/library/src/main/camera2/com/google/android/cameraview/FocusModeSelector.java
@@ -1,0 +1,46 @@
+package com.google.android.cameraview;
+
+import android.hardware.camera2.CameraCharacteristics;
+import android.hardware.camera2.CameraMetadata;
+import android.hardware.camera2.CaptureRequest;
+import android.os.Build;
+
+final class FocusModeSelector {
+    // Ordered by descending preference
+    private static int[] mPreferredAfModes = {
+            CaptureRequest.CONTROL_AF_MODE_CONTINUOUS_PICTURE,
+            CaptureRequest.CONTROL_AF_MODE_AUTO
+    };
+
+    private FocusModeSelector() {
+    }
+
+    static int getBestAfMode(CameraCharacteristics cameraCharacteristics) {
+        int[] supportedModes = cameraCharacteristics.get(CameraCharacteristics.CONTROL_AF_AVAILABLE_MODES);
+        @SuppressWarnings("ConstantConditions")
+        int hardwareLevel = cameraCharacteristics.get(CameraCharacteristics.INFO_SUPPORTED_HARDWARE_LEVEL);
+        boolean isLegacyHardware = hardwareLevel == CameraMetadata.INFO_SUPPORTED_HARDWARE_LEVEL_LEGACY;
+        boolean isSamsung = Build.MANUFACTURER.equalsIgnoreCase("Samsung");
+        for (int mode : mPreferredAfModes) {
+            // Skip continues AF, Samsung device with legacy hardware will usually not work with continuous picture.
+            // e.g. Samsung S5
+            if (mode == CaptureRequest.CONTROL_AF_MODE_CONTINUOUS_PICTURE && isLegacyHardware && isSamsung) {
+                continue;
+            }
+            if (arrayOfIntContains(supportedModes, mode)) {
+                return mode;
+            }
+        }
+        return CaptureRequest.CONTROL_AF_MODE_OFF;
+    }
+
+    private static boolean arrayOfIntContains(int[] array, int value) {
+        if (array == null) return false;
+        for (int arrayValue : array) {
+            if (arrayValue == value) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/library/src/main/camera2/com/google/android/cameraview/PictureCaptureCallback.java
+++ b/library/src/main/camera2/com/google/android/cameraview/PictureCaptureCallback.java
@@ -1,0 +1,105 @@
+package com.google.android.cameraview;
+
+import android.hardware.camera2.CameraCaptureSession;
+import android.hardware.camera2.CaptureRequest;
+import android.hardware.camera2.CaptureResult;
+import android.hardware.camera2.TotalCaptureResult;
+import android.support.annotation.NonNull;
+
+/**
+ * A {@link CameraCaptureSession.CaptureCallback} for capturing a still picture.
+ */
+abstract class PictureCaptureCallback extends CameraCaptureSession.CaptureCallback {
+    private static final int MAX_LOCK_FOCUS_ATTEMPTS = 3;
+
+    public static final int STATE_PREVIEW = 0;
+    public static final int STATE_LOCKING = 1;
+    public static final int STATE_LOCKED = 2;
+    public static final int STATE_PRECAPTURE = 3;
+    public static final int STATE_WAITING = 4;
+    public static final int STATE_CAPTURING = 5;
+
+    private int mState;
+    private int mLockFocusAttemptsCount;
+
+
+    public void setState(int state) {
+        mState = state;
+    }
+
+    public void clearLockFocusAttemptsCount() {
+        mLockFocusAttemptsCount = 0;
+    }
+
+    @Override
+    public void onCaptureProgressed(@NonNull CameraCaptureSession session,
+                                    @NonNull CaptureRequest request,
+                                    @NonNull CaptureResult partialResult) {
+        process(partialResult);
+    }
+
+    @Override
+    public void onCaptureCompleted(@NonNull CameraCaptureSession session,
+                                   @NonNull CaptureRequest request,
+                                   @NonNull TotalCaptureResult result) {
+        process(result);
+    }
+
+    private void process(@NonNull CaptureResult result) {
+        switch (mState) {
+            case STATE_LOCKING: {
+                Integer af = result.get(CaptureResult.CONTROL_AF_STATE);
+                if (af == null) {
+                    break;
+                }
+                Integer ae = result.get(CaptureResult.CONTROL_AE_STATE);
+                boolean focused = af == CaptureResult.CONTROL_AF_STATE_FOCUSED_LOCKED;
+                boolean notFocused = af == CaptureResult.CONTROL_AF_STATE_NOT_FOCUSED_LOCKED;
+                if (focused || (notFocused && mLockFocusAttemptsCount >= MAX_LOCK_FOCUS_ATTEMPTS)) {
+                    if (ae == null || ae == CaptureResult.CONTROL_AE_STATE_CONVERGED) {
+                        setState(STATE_CAPTURING);
+                        onReady();
+                    } else {
+                        setState(STATE_LOCKED);
+                        onPrecaptureRequired();
+                    }
+                } else if (notFocused) {
+                    onLockFocusRetryRequired();
+                    mLockFocusAttemptsCount++;
+                }
+                break;
+            }
+            case STATE_PRECAPTURE: {
+                Integer ae = result.get(CaptureResult.CONTROL_AE_STATE);
+                if (ae == null || ae == CaptureResult.CONTROL_AE_STATE_PRECAPTURE ||
+                        ae == CaptureRequest.CONTROL_AE_STATE_FLASH_REQUIRED ||
+                        ae == CaptureResult.CONTROL_AE_STATE_CONVERGED) {
+                    setState(STATE_WAITING);
+                }
+                break;
+            }
+            case STATE_WAITING: {
+                Integer ae = result.get(CaptureResult.CONTROL_AE_STATE);
+                if (ae == null || ae != CaptureResult.CONTROL_AE_STATE_PRECAPTURE) {
+                    setState(STATE_CAPTURING);
+                    onReady();
+                }
+                break;
+            }
+        }
+    }
+
+    /**
+     * Called when it is ready to take a still picture.
+     */
+    public abstract void onReady();
+
+    /**
+     * Called when it is necessary to run the precapture sequence.
+     */
+    public abstract void onPrecaptureRequired();
+    /**
+     * Called when locking focus has failed but MAX_LOCK_FOCUS_ATTEMPTS hasn't been reached yet
+     */
+    public abstract void onLockFocusRetryRequired();
+}

--- a/library/src/main/java/com/google/android/cameraview/CameraView.java
+++ b/library/src/main/java/com/google/android/cameraview/CameraView.java
@@ -28,6 +28,7 @@ import android.support.annotation.Nullable;
 import android.support.v4.os.ParcelableCompat;
 import android.support.v4.os.ParcelableCompatCreatorCallbacks;
 import android.util.AttributeSet;
+import android.view.MotionEvent;
 import android.view.TextureView;
 import android.widget.FrameLayout;
 
@@ -215,6 +216,23 @@ public class CameraView extends FrameLayout {
         setAspectRatio(ss.ratio);
         setAutoFocus(ss.autoFocus);
         setFlash(ss.flash);
+    }
+
+    @Override
+    public boolean onTouchEvent(MotionEvent event) {
+        final int actionMasked = event.getActionMasked();
+        if (actionMasked != MotionEvent.ACTION_DOWN) {
+            return false;
+        }
+
+        final int x = (int) event.getX();
+        final int y = (int) event.getY();
+        if (mImpl instanceof TapFocusable) {
+            ((TapFocusable) mImpl).setFocusTarget(x, y);
+            return true;
+        }
+
+        return super.onTouchEvent(event);
     }
 
     /**

--- a/library/src/main/java/com/google/android/cameraview/CameraView.java
+++ b/library/src/main/java/com/google/android/cameraview/CameraView.java
@@ -218,11 +218,22 @@ public class CameraView extends FrameLayout {
     }
 
     /**
-     * Open a camera device and start showing camera preview. This is typically called from
+     * Open a camera device and start showing camera preview for taking pictures. This is typically called from
      * {@link Activity#onResume()}.
      */
-    public void start() {
-        mImpl.start();
+    public void startPictureMode() {
+        mImpl.startPictureMode();
+    }
+
+
+    /**
+     * Open a camera device and start showing camera preview for video recording. This is typically called from
+     * {@link Activity#onResume()}.
+     *
+     * @param videoFilePath A path to a file where the video will be saved
+     */
+    public void startVideoMode(String videoFilePath) {
+        mImpl.startVideoMode(videoFilePath);
     }
 
     /**
@@ -438,11 +449,9 @@ public class CameraView extends FrameLayout {
 
     /**
      * Start recording a video.
-     *
-     * @param videoFilePath File path where the video will be stored.
      */
-    public void startRecordingVideo(String videoFilePath) {
-        mImpl.startRecordingVideo(videoFilePath);
+    public void startRecordingVideo() {
+        mImpl.startRecordingVideo();
     }
 
     /**

--- a/library/src/main/java/com/google/android/cameraview/CameraView.java
+++ b/library/src/main/java/com/google/android/cameraview/CameraView.java
@@ -34,6 +34,7 @@ import android.widget.FrameLayout;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.util.ArrayList;
+import java.util.List;
 import java.util.Set;
 
 public class CameraView extends FrameLayout {
@@ -107,11 +108,9 @@ public class CameraView extends FrameLayout {
         setVideoFrameRate(a.getInt(R.styleable.CameraView_videoFrameRate, 30));
         setMinVideoWidth(a.getInt(R.styleable.CameraView_minVideoWidth, 0));
         setMinVideoHeight(a.getInt(R.styleable.CameraView_minVideoHeight, 0));
-        String aspectRatio = a.getString(R.styleable.CameraView_aspectRatio);
-        if (aspectRatio != null) {
-            setAspectRatio(AspectRatio.parse(aspectRatio));
-        } else {
-            setAspectRatio(Constants.DEFAULT_ASPECT_RATIO);
+        String ratios = a.getString(R.styleable.CameraView_preferredAspectRatios);
+        if (ratios != null) {
+            setPreferredAspectRatio(parseAspectRatios(ratios));
         }
         setAutoFocus(a.getBoolean(R.styleable.CameraView_autoFocus, true));
         setFlash(a.getInt(R.styleable.CameraView_flash, Constants.FLASH_AUTO));
@@ -123,6 +122,16 @@ public class CameraView extends FrameLayout {
                 mImpl.setDisplayOrientation(displayOrientation);
             }
         };
+    }
+
+    private AspectRatio[] parseAspectRatios(@NonNull String ratiosInput) {
+        String[] ratioStrings = ratiosInput.split("\\|");
+        List<AspectRatio> aspectRatios = new ArrayList<>(ratioStrings.length);
+        for (String ratio : ratioStrings) {
+            aspectRatios.add(AspectRatio.parse(ratio.trim()));
+        }
+        AspectRatio[] result = new AspectRatio[aspectRatios.size()];
+        return aspectRatios.toArray(result);
     }
 
     @Override
@@ -197,7 +206,7 @@ public class CameraView extends FrameLayout {
     protected Parcelable onSaveInstanceState() {
         SavedState state = new SavedState(super.onSaveInstanceState());
         state.facing = getFacing();
-        state.ratio = getAspectRatio();
+        state.preferredRatios = getPreferredAspectRatios();
         state.autoFocus = getAutoFocus();
         state.flash = getFlash();
         return state;
@@ -212,7 +221,7 @@ public class CameraView extends FrameLayout {
         SavedState ss = (SavedState) state;
         super.onRestoreInstanceState(ss.getSuperState());
         setFacing(ss.facing);
-        setAspectRatio(ss.ratio);
+        setPreferredAspectRatio(ss.preferredRatios);
         setAutoFocus(ss.autoFocus);
         setFlash(ss.flash);
     }
@@ -222,6 +231,7 @@ public class CameraView extends FrameLayout {
      * {@link Activity#onResume()}.
      */
     public void startPictureMode() {
+        mImpl.setScreenOrientation(getResources().getConfiguration().orientation);
         mImpl.startPictureMode();
     }
 
@@ -229,11 +239,10 @@ public class CameraView extends FrameLayout {
     /**
      * Open a camera device and start showing camera preview for video recording. This is typically called from
      * {@link Activity#onResume()}.
-     *
-     * @param videoFilePath A path to a file where the video will be saved
      */
-    public void startVideoMode(String videoFilePath) {
-        mImpl.startVideoMode(videoFilePath);
+    public void startVideoMode() {
+        mImpl.setScreenOrientation(getResources().getConfiguration().orientation);
+        mImpl.startVideoMode();
     }
 
     /**
@@ -386,18 +395,28 @@ public class CameraView extends FrameLayout {
     }
 
     /**
-     * Sets the aspect ratio of camera.
+     * Sets the preferred aspect ratios for the camera output.
+     * The first ratio in the array will be set if the camera supports it, if not the second will
+     * be picked and so on. If none of the ratios in the list is supported or the list is empty,
+     * the CameraView will fallback to the ratio of the largest picture size available that matches
+     * the screen orientation.
      *
-     * @param ratio The {@link AspectRatio} to be set.
+     * @param aspectRatios An array of {@link AspectRatio} ordered by preference
      */
-    public void setAspectRatio(@NonNull AspectRatio ratio) {
-        if (mImpl.setAspectRatio(ratio)) {
+    public void setPreferredAspectRatio(AspectRatio[] aspectRatios) {
+        if (mImpl.setPreferredAspectRatios(aspectRatios)) {
             requestLayout();
         }
     }
 
+    public AspectRatio[] getPreferredAspectRatios() {
+        return mImpl.getPreferredAspectRatios();
+    }
+
     /**
      * Gets the current aspect ratio of camera.
+     * This ratio is chosen based on the preferred ratios and the ratios supported by the camera.
+     * There is no guarantee that is one of the preferred aspect ratios
      *
      * @return The current {@link AspectRatio}. Can be {@code null} if no camera is opened yet.
      */
@@ -449,9 +468,11 @@ public class CameraView extends FrameLayout {
 
     /**
      * Start recording a video.
+     *
+     * @param videoFilePath a path to the file where the video will be saved
      */
-    public void startRecordingVideo() {
-        mImpl.startRecordingVideo();
+    public void startRecordingVideo(String videoFilePath) {
+        mImpl.startRecordingVideo(videoFilePath);
     }
 
     /**
@@ -530,7 +551,7 @@ public class CameraView extends FrameLayout {
         @Facing
         int facing;
 
-        AspectRatio ratio;
+        AspectRatio[] preferredRatios;
 
         boolean autoFocus;
 
@@ -541,7 +562,7 @@ public class CameraView extends FrameLayout {
         public SavedState(Parcel source, ClassLoader loader) {
             super(source);
             facing = source.readInt();
-            ratio = source.readParcelable(loader);
+            preferredRatios = source.createTypedArray(AspectRatio.CREATOR);
             autoFocus = source.readByte() != 0;
             flash = source.readInt();
         }
@@ -554,7 +575,7 @@ public class CameraView extends FrameLayout {
         public void writeToParcel(Parcel out, int flags) {
             super.writeToParcel(out, flags);
             out.writeInt(facing);
-            out.writeParcelable(ratio, 0);
+            out.writeTypedArray(preferredRatios, 0);
             out.writeByte((byte) (autoFocus ? 1 : 0));
             out.writeInt(flash);
         }

--- a/library/src/main/java/com/google/android/cameraview/CameraView.java
+++ b/library/src/main/java/com/google/android/cameraview/CameraView.java
@@ -380,7 +380,9 @@ public class CameraView extends FrameLayout {
      * @param ratio The {@link AspectRatio} to be set.
      */
     public void setAspectRatio(@NonNull AspectRatio ratio) {
-        mImpl.setAspectRatio(ratio);
+        if (mImpl.setAspectRatio(ratio)) {
+            requestLayout();
+        }
     }
 
     /**

--- a/library/src/main/java/com/google/android/cameraview/CameraView.java
+++ b/library/src/main/java/com/google/android/cameraview/CameraView.java
@@ -28,7 +28,6 @@ import android.support.annotation.Nullable;
 import android.support.v4.os.ParcelableCompat;
 import android.support.v4.os.ParcelableCompatCreatorCallbacks;
 import android.util.AttributeSet;
-import android.view.MotionEvent;
 import android.view.TextureView;
 import android.widget.FrameLayout;
 
@@ -216,23 +215,6 @@ public class CameraView extends FrameLayout {
         setAspectRatio(ss.ratio);
         setAutoFocus(ss.autoFocus);
         setFlash(ss.flash);
-    }
-
-    @Override
-    public boolean onTouchEvent(MotionEvent event) {
-        final int actionMasked = event.getActionMasked();
-        if (actionMasked != MotionEvent.ACTION_DOWN) {
-            return false;
-        }
-
-        final int x = (int) event.getX();
-        final int y = (int) event.getY();
-        if (mImpl instanceof TapFocusable) {
-            ((TapFocusable) mImpl).setFocusTarget(x, y);
-            return true;
-        }
-
-        return super.onTouchEvent(event);
     }
 
     /**

--- a/library/src/main/res/values/attrs.xml
+++ b/library/src/main/res/values/attrs.xml
@@ -25,8 +25,10 @@
             <!-- The camera device faces the same direction as the device's screen. -->
             <enum name="front" value="1"/>
         </attr>
-        <!-- Aspect ratio of camera preview and pictures. -->
-        <attr name="aspectRatio" format="string"/>
+        <!--
+         Preferred aspect ratios for the camera separated by '|' and ordered by desc preference.
+         -->
+        <attr name="preferredAspectRatios" format="string"/>
         <!-- Continuous auto focus mode. -->
         <attr name="autoFocus" format="boolean"/>
         <!-- The flash mode. -->

--- a/library/src/main/res/values/styles.xml
+++ b/library/src/main/res/values/styles.xml
@@ -16,7 +16,7 @@
     <style name="Widget.CameraView" parent="android:Widget">
         <item name="android:adjustViewBounds">false</item>
         <item name="facing">back</item>
-        <item name="aspectRatio">4:3</item>
+        <item name="preferredAspectRatios">4:3</item>
         <item name="autoFocus">true</item>
         <item name="flash">auto</item>
     </style>


### PR DESCRIPTION
* Implement new logic to select focus mode in `FocusModeSelector`. This take into account that legacy Samsung devices tend not to work with continuous AF mode even though they say it's supported.
* Separate video and picture mode. Now we have to start the cameraview in one of those two modes depending on whether you are going to take pictures or record video. This allows to calculate the outputs sizes based on the MediaRecorder for video or ImageReader for picture mode (before it would always calculate the output sizes based on the ImageReader, that was incorrect)
* Add support for multiple "preferred aspect ratios". Before it wasn't clear that the aspect ratio that you set may not be supported by the output of the camera. Now we can set multiple preferred ratios ordered by preference. This allows to to chose a second, or third best ratio in case the first one is not supported. It also implements better support for the fallback ratio in case non of the preferred ones is supported. 
* Implements focus retry attempts, up to a maximum of 3. This slightly improves focusing on devices that don't support continuous focusing and usually struggle to focus, like the Samsung S5.
* Move some code out of `Camera2.java` and put it in a different file so that the first one is less bloated
* Unfortunately there are a bunch of formatting changes due to our Android studio formatting rules being quite different to the original cameraview :(