### PR TITLE
Fix the auto focus loop in the Motorola Moto G phone.

### DIFF
--- a/library/src/main/camera2/com/google/android/cameraview/FocusModeSelector.java
+++ b/library/src/main/camera2/com/google/android/cameraview/FocusModeSelector.java
@@ -20,11 +20,10 @@ final class FocusModeSelector {
         @SuppressWarnings("ConstantConditions")
         int hardwareLevel = cameraCharacteristics.get(CameraCharacteristics.INFO_SUPPORTED_HARDWARE_LEVEL);
         boolean isLegacyHardware = hardwareLevel == CameraMetadata.INFO_SUPPORTED_HARDWARE_LEVEL_LEGACY;
-        boolean isSamsung = Build.MANUFACTURER.equalsIgnoreCase("Samsung");
         for (int mode : mPreferredAfModes) {
-            // Skip continues AF, Samsung device with legacy hardware will usually not work with continuous picture.
-            // e.g. Samsung S5
-            if (mode == CaptureRequest.CONTROL_AF_MODE_CONTINUOUS_PICTURE && isLegacyHardware && isSamsung) {
+            // Skip continuous AF, since some devices with legacy hardware will not work with continuous picture.
+            // e.g. Samsung S5, Motorola Moto G
+            if (mode == CaptureRequest.CONTROL_AF_MODE_CONTINUOUS_PICTURE && isLegacyHardware) {
                 continue;
             }
             if (arrayOfIntContains(supportedModes, mode)) {


### PR DESCRIPTION
Use the CONTROL_AF_MODE_AUTO auto focus mode for all legacy devices (and not just samsung). This still works, although with a slightly degraded experience. Users of those devices will only have their picture get focus when they press the button to take the picture.