### PR TITLE
Refactor code that selects the optimal preview size

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,6 +11,7 @@ buildscript {
 allprojects {
     repositories {
         jcenter()
+        google()
     }
 }
 
@@ -19,9 +20,9 @@ task clean(type: Delete) {
 }
 
 ext {
-    buildToolsVersion = '26.0.1'
-    compileSdkVersion = 26
+    buildToolsVersion = '26.0.2'
+    compileSdkVersion = 27
     minSdkVersion = 21
-    targetSdkVersion = 25
+    targetSdkVersion = 27
     supportLibraryVersion = '26.1.0'
 }

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -42,6 +42,7 @@ android {
 dependencies {
     implementation "com.android.support:support-annotations:$supportLibraryVersion"
     implementation "com.android.support:support-v4:$supportLibraryVersion"
+    implementation 'com.jakewharton.timber:timber:4.5.1'
 
     // Tests
     testImplementation 'junit:junit:4.12'

--- a/library/src/main/base/com/google/android/cameraview/AspectRatio.java
+++ b/library/src/main/base/com/google/android/cameraview/AspectRatio.java
@@ -137,6 +137,8 @@ public class AspectRatio implements Comparable<AspectRatio>, Parcelable {
         return (float) mX / mY;
     }
 
+
+
     @Override
     public int hashCode() {
         // assuming most sizes are <2^16, doing a rotate will give us perfect hashing

--- a/library/src/main/base/com/google/android/cameraview/AspectRatio.java
+++ b/library/src/main/base/com/google/android/cameraview/AspectRatio.java
@@ -137,8 +137,6 @@ public class AspectRatio implements Comparable<AspectRatio>, Parcelable {
         return (float) mX / mY;
     }
 
-
-
     @Override
     public int hashCode() {
         // assuming most sizes are <2^16, doing a rotate will give us perfect hashing

--- a/library/src/main/base/com/google/android/cameraview/CameraViewImpl.java
+++ b/library/src/main/base/com/google/android/cameraview/CameraViewImpl.java
@@ -62,15 +62,6 @@ abstract class CameraViewImpl {
     abstract Set<AspectRatio> getSupportedAspectRatios();
 
     /**
-     * @return {@code true} if the aspect ratio was changed.
-     */
-    abstract boolean setPreferredAspectRatios(AspectRatio[] ratios);
-
-    abstract AspectRatio[] getPreferredAspectRatios();
-
-    abstract AspectRatio getAspectRatio();
-
-    /**
      * Overall orientation of the screen. May be one of
      * {@link android.content.res.Configuration#ORIENTATION_LANDSCAPE},
      * {@link android.content.res.Configuration#ORIENTATION_PORTRAIT}.

--- a/library/src/main/base/com/google/android/cameraview/CameraViewImpl.java
+++ b/library/src/main/base/com/google/android/cameraview/CameraViewImpl.java
@@ -61,13 +61,6 @@ abstract class CameraViewImpl {
 
     abstract Set<AspectRatio> getSupportedAspectRatios();
 
-    /**
-     * Overall orientation of the screen. May be one of
-     * {@link android.content.res.Configuration#ORIENTATION_LANDSCAPE},
-     * {@link android.content.res.Configuration#ORIENTATION_PORTRAIT}.
-     */
-    abstract void setScreenOrientation(int screenOrientation);
-
     abstract void setAutoFocus(boolean autoFocus);
 
     abstract boolean getAutoFocus();

--- a/library/src/main/base/com/google/android/cameraview/Size.java
+++ b/library/src/main/base/com/google/android/cameraview/Size.java
@@ -45,6 +45,10 @@ public class Size implements Comparable<Size> {
         return mHeight;
     }
 
+    public AspectRatio getAspectRatio() {
+        return AspectRatio.of(mWidth, mHeight);
+    }
+
     public long getArea() {
         // We cast here to ensure the multiplications won't overflow
         return (long) mWidth * mHeight;

--- a/library/src/main/base/com/google/android/cameraview/SizeMap.java
+++ b/library/src/main/base/com/google/android/cameraview/SizeMap.java
@@ -21,8 +21,10 @@ import android.support.annotation.Nullable;
 import android.support.v4.util.ArrayMap;
 import android.support.v4.util.ArraySet;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.List;
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
@@ -72,6 +74,22 @@ class SizeMap {
         return mRatios.keySet();
     }
 
+    List<AspectRatio> ratiosSortedByClosest(final AspectRatio aspectRatio) {
+        List<AspectRatio> aspectRatios = new ArrayList<>(ratios());
+        Collections.sort(aspectRatios, new Comparator<AspectRatio>() {
+            @Override public int compare(AspectRatio ratio1, AspectRatio ratio2) {
+                float aspectRatioValue = aspectRatio.toFloat();
+                float ratio1Value = ratio1.toFloat();
+                float ratio2Value = ratio2.toFloat();
+
+                float ratio1Diff = Math.abs(ratio1Value - aspectRatioValue);
+                float ratio2Diff = Math.abs(ratio2Value - aspectRatioValue);
+                return Float.compare(ratio1Diff, ratio2Diff);
+            }
+        });
+        return aspectRatios;
+    }
+
     SortedSet<Size> sizes(AspectRatio ratio) {
         if (mRatios.containsKey(ratio)) {
             return mRatios.get(ratio);
@@ -79,18 +97,12 @@ class SizeMap {
         return new TreeSet<>();
     }
 
-    Size largest(int preferredOrientation) {
+    Size largest() {
         Set<Size> preferredSizes = new ArraySet<>();
-        Set<Size> otherSizes = new ArraySet<>();
         for (AspectRatio ratio : mRatios.keySet()) {
-            if (ratio.matchesOrientation(preferredOrientation)) {
                 preferredSizes.addAll(mRatios.get(ratio));
-            } else {
-                otherSizes.addAll(mRatios.get(ratio));
-            }
         }
-
-        return Collections.max(!preferredSizes.isEmpty() ? preferredSizes : otherSizes, new CompareSizesByArea());
+        return Collections.max(preferredSizes, new CompareSizesByArea());
     }
 
     void clear() {

--- a/library/src/main/java/com/google/android/cameraview/CameraView.java
+++ b/library/src/main/java/com/google/android/cameraview/CameraView.java
@@ -108,10 +108,6 @@ public class CameraView extends FrameLayout {
         setVideoFrameRate(a.getInt(R.styleable.CameraView_videoFrameRate, 30));
         setMinVideoWidth(a.getInt(R.styleable.CameraView_minVideoWidth, 0));
         setMinVideoHeight(a.getInt(R.styleable.CameraView_minVideoHeight, 0));
-        String ratios = a.getString(R.styleable.CameraView_preferredAspectRatios);
-        if (ratios != null) {
-            setPreferredAspectRatio(parseAspectRatios(ratios));
-        }
         setAutoFocus(a.getBoolean(R.styleable.CameraView_autoFocus, true));
         setFlash(a.getInt(R.styleable.CameraView_flash, Constants.FLASH_AUTO));
         a.recycle();
@@ -124,15 +120,15 @@ public class CameraView extends FrameLayout {
         };
     }
 
-    private AspectRatio[] parseAspectRatios(@NonNull String ratiosInput) {
-        String[] ratioStrings = ratiosInput.split("\\|");
-        List<AspectRatio> aspectRatios = new ArrayList<>(ratioStrings.length);
-        for (String ratio : ratioStrings) {
-            aspectRatios.add(AspectRatio.parse(ratio.trim()));
-        }
-        AspectRatio[] result = new AspectRatio[aspectRatios.size()];
-        return aspectRatios.toArray(result);
-    }
+//    private AspectRatio[] parseAspectRatios(@NonNull String ratiosInput) {
+//        String[] ratioStrings = ratiosInput.split("\\|");
+//        List<AspectRatio> aspectRatios = new ArrayList<>(ratioStrings.length);
+//        for (String ratio : ratioStrings) {
+//            aspectRatios.add(AspectRatio.parse(ratio.trim()));
+//        }
+//        AspectRatio[] result = new AspectRatio[aspectRatios.size()];
+//        return aspectRatios.toArray(result);
+//    }
 
     @Override
     protected void onAttachedToWindow() {
@@ -149,68 +145,67 @@ public class CameraView extends FrameLayout {
     @Override
     protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
         // Handle android:adjustViewBounds
-        if (mAdjustViewBounds) {
-            if (!isCameraOpened()) {
-                mCallbacks.reserveRequestLayoutOnOpen();
-                super.onMeasure(widthMeasureSpec, heightMeasureSpec);
-                return;
-            }
-            final int widthMode = MeasureSpec.getMode(widthMeasureSpec);
-            final int heightMode = MeasureSpec.getMode(heightMeasureSpec);
-            if (widthMode == MeasureSpec.EXACTLY && heightMode != MeasureSpec.EXACTLY) {
-                final AspectRatio ratio = getAspectRatio();
-                assert ratio != null;
-                int height = (int) (MeasureSpec.getSize(widthMeasureSpec) * ratio.toFloat());
-                if (heightMode == MeasureSpec.AT_MOST) {
-                    height = Math.min(height, MeasureSpec.getSize(heightMeasureSpec));
-                }
-                super.onMeasure(widthMeasureSpec,
-                        MeasureSpec.makeMeasureSpec(height, MeasureSpec.EXACTLY));
-            } else if (widthMode != MeasureSpec.EXACTLY && heightMode == MeasureSpec.EXACTLY) {
-                final AspectRatio ratio = getAspectRatio();
-                assert ratio != null;
-                int width = (int) (MeasureSpec.getSize(heightMeasureSpec) * ratio.toFloat());
-                if (widthMode == MeasureSpec.AT_MOST) {
-                    width = Math.min(width, MeasureSpec.getSize(widthMeasureSpec));
-                }
-                super.onMeasure(MeasureSpec.makeMeasureSpec(width, MeasureSpec.EXACTLY),
-                        heightMeasureSpec);
-            } else {
-                super.onMeasure(widthMeasureSpec, heightMeasureSpec);
-            }
-        } else {
-            super.onMeasure(widthMeasureSpec, heightMeasureSpec);
-        }
-        // Measure the TextureView
-        int width = getMeasuredWidth();
-        int height = getMeasuredHeight();
-        AspectRatio ratio = getAspectRatio();
-        if (ratio == null) {
-            return;
-        }
-
-        if (mDisplayOrientationDetector.getLastKnownDisplayOrientation() % 180 == 0) {
-            ratio = ratio.inverse();
-        }
-
-        if (height < width * ratio.getY() / ratio.getX()) {
-            mTextureView.measure(
-                    MeasureSpec.makeMeasureSpec(width, MeasureSpec.EXACTLY),
-                    MeasureSpec.makeMeasureSpec(width * ratio.getY() / ratio.getX(),
-                            MeasureSpec.EXACTLY));
-        } else {
-            mTextureView.measure(
-                    MeasureSpec.makeMeasureSpec(height * ratio.getX() / ratio.getY(),
-                            MeasureSpec.EXACTLY),
-                    MeasureSpec.makeMeasureSpec(height, MeasureSpec.EXACTLY));
-        }
+//        if (mAdjustViewBounds) {
+//            if (!isCameraOpened()) {
+//                mCallbacks.reserveRequestLayoutOnOpen();
+//                super.onMeasure(widthMeasureSpec, heightMeasureSpec);
+//                return;
+//            }
+//            final int widthMode = MeasureSpec.getMode(widthMeasureSpec);
+//            final int heightMode = MeasureSpec.getMode(heightMeasureSpec);
+//            if (widthMode == MeasureSpec.EXACTLY && heightMode != MeasureSpec.EXACTLY) {
+//                final AspectRatio ratio = getAspectRatio();
+//                assert ratio != null;
+//                int height = (int) (MeasureSpec.getSize(widthMeasureSpec) * ratio.toFloat());
+//                if (heightMode == MeasureSpec.AT_MOST) {
+//                    height = Math.min(height, MeasureSpec.getSize(heightMeasureSpec));
+//                }
+//                super.onMeasure(widthMeasureSpec,
+//                        MeasureSpec.makeMeasureSpec(height, MeasureSpec.EXACTLY));
+//            } else if (widthMode != MeasureSpec.EXACTLY && heightMode == MeasureSpec.EXACTLY) {
+//                final AspectRatio ratio = getAspectRatio();
+//                assert ratio != null;
+//                int width = (int) (MeasureSpec.getSize(heightMeasureSpec) * ratio.toFloat());
+//                if (widthMode == MeasureSpec.AT_MOST) {
+//                    width = Math.min(width, MeasureSpec.getSize(widthMeasureSpec));
+//                }
+//                super.onMeasure(MeasureSpec.makeMeasureSpec(width, MeasureSpec.EXACTLY),
+//                        heightMeasureSpec);
+//            } else {
+//                super.onMeasure(widthMeasureSpec, heightMeasureSpec);
+//            }
+//        } else {
+//            super.onMeasure(widthMeasureSpec, heightMeasureSpec);
+//        }
+//        // Measure the TextureView
+//        int width = getMeasuredWidth();
+//        int height = getMeasuredHeight();
+//        AspectRatio ratio = getAspectRatio();
+//        if (ratio == null) {
+//            return;
+//        }
+//
+//        if (mDisplayOrientationDetector.getLastKnownDisplayOrientation() % 180 == 0) {
+//            ratio = ratio.inverse();
+//        }
+//
+//        if (height < width * ratio.getY() / ratio.getX()) {
+//            mTextureView.measure(
+//                    MeasureSpec.makeMeasureSpec(width, MeasureSpec.EXACTLY),
+//                    MeasureSpec.makeMeasureSpec(width * ratio.getY() / ratio.getX(),
+//                            MeasureSpec.EXACTLY));
+//        } else {
+//            mTextureView.measure(
+//                    MeasureSpec.makeMeasureSpec(height * ratio.getX() / ratio.getY(),
+//                            MeasureSpec.EXACTLY),
+//                    MeasureSpec.makeMeasureSpec(height, MeasureSpec.EXACTLY));
+//        }
     }
 
     @Override
     protected Parcelable onSaveInstanceState() {
         SavedState state = new SavedState(super.onSaveInstanceState());
         state.facing = getFacing();
-        state.preferredRatios = getPreferredAspectRatios();
         state.autoFocus = getAutoFocus();
         state.flash = getFlash();
         return state;
@@ -225,7 +220,6 @@ public class CameraView extends FrameLayout {
         SavedState ss = (SavedState) state;
         super.onRestoreInstanceState(ss.getSuperState());
         setFacing(ss.facing);
-        setPreferredAspectRatio(ss.preferredRatios);
         setAutoFocus(ss.autoFocus);
         setFlash(ss.flash);
     }
@@ -399,37 +393,6 @@ public class CameraView extends FrameLayout {
     }
 
     /**
-     * Sets the preferred aspect ratios for the camera output.
-     * The first ratio in the array will be set if the camera supports it, if not the second will
-     * be picked and so on. If none of the ratios in the list is supported or the list is empty,
-     * the CameraView will fallback to the ratio of the largest picture size available that matches
-     * the screen orientation.
-     *
-     * @param aspectRatios An array of {@link AspectRatio} ordered by preference
-     */
-    public void setPreferredAspectRatio(AspectRatio[] aspectRatios) {
-        if (mImpl.setPreferredAspectRatios(aspectRatios)) {
-            requestLayout();
-        }
-    }
-
-    public AspectRatio[] getPreferredAspectRatios() {
-        return mImpl.getPreferredAspectRatios();
-    }
-
-    /**
-     * Gets the current aspect ratio of camera.
-     * This ratio is chosen based on the preferred ratios and the ratios supported by the camera.
-     * There is no guarantee that is one of the preferred aspect ratios
-     *
-     * @return The current {@link AspectRatio}. Can be {@code null} if no camera is opened yet.
-     */
-    @Nullable
-    public AspectRatio getAspectRatio() {
-        return mImpl.getAspectRatio();
-    }
-
-    /**
      * Enables or disables the continuous auto-focus mode. When the current camera doesn't support
      * auto-focus, calling this method will be ignored.
      *
@@ -555,8 +518,6 @@ public class CameraView extends FrameLayout {
         @Facing
         int facing;
 
-        AspectRatio[] preferredRatios;
-
         boolean autoFocus;
 
         @Flash
@@ -566,7 +527,6 @@ public class CameraView extends FrameLayout {
         public SavedState(Parcel source, ClassLoader loader) {
             super(source);
             facing = source.readInt();
-            preferredRatios = source.createTypedArray(AspectRatio.CREATOR);
             autoFocus = source.readByte() != 0;
             flash = source.readInt();
         }
@@ -579,7 +539,6 @@ public class CameraView extends FrameLayout {
         public void writeToParcel(Parcel out, int flags) {
             super.writeToParcel(out, flags);
             out.writeInt(facing);
-            out.writeTypedArray(preferredRatios, 0);
             out.writeByte((byte) (autoFocus ? 1 : 0));
             out.writeInt(flash);
         }

--- a/library/src/main/java/com/google/android/cameraview/CameraView.java
+++ b/library/src/main/java/com/google/android/cameraview/CameraView.java
@@ -75,8 +75,6 @@ public class CameraView extends FrameLayout {
 
     private final CallbackBridge mCallbacks;
 
-    private boolean mAdjustViewBounds;
-
     private final TextureView mTextureView;
 
     private final DisplayOrientationDetector mDisplayOrientationDetector;
@@ -102,7 +100,6 @@ public class CameraView extends FrameLayout {
         // Attributes
         TypedArray a = context.obtainStyledAttributes(attrs, R.styleable.CameraView, defStyleAttr,
                 R.style.Widget_CameraView);
-        mAdjustViewBounds = a.getBoolean(R.styleable.CameraView_android_adjustViewBounds, false);
         setFacing(a.getInt(R.styleable.CameraView_facing, FACING_BACK));
         setVideoEncodingBitRate(a.getInt(R.styleable.CameraView_videoEncodingBitRate, 5000000));
         setVideoFrameRate(a.getInt(R.styleable.CameraView_videoFrameRate, 30));
@@ -120,16 +117,6 @@ public class CameraView extends FrameLayout {
         };
     }
 
-//    private AspectRatio[] parseAspectRatios(@NonNull String ratiosInput) {
-//        String[] ratioStrings = ratiosInput.split("\\|");
-//        List<AspectRatio> aspectRatios = new ArrayList<>(ratioStrings.length);
-//        for (String ratio : ratioStrings) {
-//            aspectRatios.add(AspectRatio.parse(ratio.trim()));
-//        }
-//        AspectRatio[] result = new AspectRatio[aspectRatios.size()];
-//        return aspectRatios.toArray(result);
-//    }
-
     @Override
     protected void onAttachedToWindow() {
         super.onAttachedToWindow();
@@ -140,66 +127,6 @@ public class CameraView extends FrameLayout {
     protected void onDetachedFromWindow() {
         mDisplayOrientationDetector.disable();
         super.onDetachedFromWindow();
-    }
-
-    @Override
-    protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
-        // Handle android:adjustViewBounds
-//        if (mAdjustViewBounds) {
-//            if (!isCameraOpened()) {
-//                mCallbacks.reserveRequestLayoutOnOpen();
-//                super.onMeasure(widthMeasureSpec, heightMeasureSpec);
-//                return;
-//            }
-//            final int widthMode = MeasureSpec.getMode(widthMeasureSpec);
-//            final int heightMode = MeasureSpec.getMode(heightMeasureSpec);
-//            if (widthMode == MeasureSpec.EXACTLY && heightMode != MeasureSpec.EXACTLY) {
-//                final AspectRatio ratio = getAspectRatio();
-//                assert ratio != null;
-//                int height = (int) (MeasureSpec.getSize(widthMeasureSpec) * ratio.toFloat());
-//                if (heightMode == MeasureSpec.AT_MOST) {
-//                    height = Math.min(height, MeasureSpec.getSize(heightMeasureSpec));
-//                }
-//                super.onMeasure(widthMeasureSpec,
-//                        MeasureSpec.makeMeasureSpec(height, MeasureSpec.EXACTLY));
-//            } else if (widthMode != MeasureSpec.EXACTLY && heightMode == MeasureSpec.EXACTLY) {
-//                final AspectRatio ratio = getAspectRatio();
-//                assert ratio != null;
-//                int width = (int) (MeasureSpec.getSize(heightMeasureSpec) * ratio.toFloat());
-//                if (widthMode == MeasureSpec.AT_MOST) {
-//                    width = Math.min(width, MeasureSpec.getSize(widthMeasureSpec));
-//                }
-//                super.onMeasure(MeasureSpec.makeMeasureSpec(width, MeasureSpec.EXACTLY),
-//                        heightMeasureSpec);
-//            } else {
-//                super.onMeasure(widthMeasureSpec, heightMeasureSpec);
-//            }
-//        } else {
-//            super.onMeasure(widthMeasureSpec, heightMeasureSpec);
-//        }
-//        // Measure the TextureView
-//        int width = getMeasuredWidth();
-//        int height = getMeasuredHeight();
-//        AspectRatio ratio = getAspectRatio();
-//        if (ratio == null) {
-//            return;
-//        }
-//
-//        if (mDisplayOrientationDetector.getLastKnownDisplayOrientation() % 180 == 0) {
-//            ratio = ratio.inverse();
-//        }
-//
-//        if (height < width * ratio.getY() / ratio.getX()) {
-//            mTextureView.measure(
-//                    MeasureSpec.makeMeasureSpec(width, MeasureSpec.EXACTLY),
-//                    MeasureSpec.makeMeasureSpec(width * ratio.getY() / ratio.getX(),
-//                            MeasureSpec.EXACTLY));
-//        } else {
-//            mTextureView.measure(
-//                    MeasureSpec.makeMeasureSpec(height * ratio.getX() / ratio.getY(),
-//                            MeasureSpec.EXACTLY),
-//                    MeasureSpec.makeMeasureSpec(height, MeasureSpec.EXACTLY));
-//        }
     }
 
     @Override
@@ -229,7 +156,6 @@ public class CameraView extends FrameLayout {
      * {@link Activity#onResume()}.
      */
     public void startPictureMode() {
-        mImpl.setScreenOrientation(getResources().getConfiguration().orientation);
         mImpl.startPictureMode();
     }
 
@@ -239,7 +165,6 @@ public class CameraView extends FrameLayout {
      * {@link Activity#onResume()}.
      */
     public void startVideoMode() {
-        mImpl.setScreenOrientation(getResources().getConfiguration().orientation);
         mImpl.startVideoMode();
     }
 
@@ -276,27 +201,6 @@ public class CameraView extends FrameLayout {
      */
     public void removeCallback(@NonNull Callback callback) {
         mCallbacks.remove(callback);
-    }
-
-    /**
-     * @param adjustViewBounds {@code true} if you want the CameraView to adjust its bounds to
-     *                         preserve the aspect ratio of camera.
-     * @see #getAdjustViewBounds()
-     */
-    public void setAdjustViewBounds(boolean adjustViewBounds) {
-        if (mAdjustViewBounds != adjustViewBounds) {
-            mAdjustViewBounds = adjustViewBounds;
-            requestLayout();
-        }
-    }
-
-    /**
-     * @return True when this CameraView is adjusting its bounds to preserve the aspect ratio of
-     * camera.
-     * @see #setAdjustViewBounds(boolean)
-     */
-    public boolean getAdjustViewBounds() {
-        return mAdjustViewBounds;
     }
 
     /**

--- a/library/src/main/res/values/attrs.xml
+++ b/library/src/main/res/values/attrs.xml
@@ -13,11 +13,6 @@
 -->
 <resources>
     <declare-styleable name="CameraView">
-        <!--
-          Set this to true if you want the CameraView to adjust its bounds to preserve the aspect
-          ratio of its camera preview.
-        -->
-        <attr name="android:adjustViewBounds"/>
         <!-- Direction the camera faces relative to device screen. -->
         <attr name="facing" format="enum">
             <!-- The camera device faces the opposite direction as the device's screen. -->
@@ -25,10 +20,6 @@
             <!-- The camera device faces the same direction as the device's screen. -->
             <enum name="front" value="1"/>
         </attr>
-        <!--
-         Preferred aspect ratios for the camera separated by '|' and ordered by desc preference.
-         -->
-        <attr name="preferredAspectRatios" format="string"/>
         <!-- Continuous auto focus mode. -->
         <attr name="autoFocus" format="boolean"/>
         <!-- The flash mode. -->

--- a/library/src/main/res/values/styles.xml
+++ b/library/src/main/res/values/styles.xml
@@ -14,9 +14,7 @@
 <resources>
 
     <style name="Widget.CameraView" parent="android:Widget">
-        <item name="android:adjustViewBounds">false</item>
         <item name="facing">back</item>
-        <item name="preferredAspectRatios">4:3</item>
         <item name="autoFocus">true</item>
         <item name="flash">auto</item>
     </style>


### PR DESCRIPTION
We had an issue on the new Pixel 2 where the algorithm that selects the optimal preview size based on a list of preferred ratios would not work very well and it would select very tiny resolutions for the camera preview. This result into weird behaviours when taking pictures and videos on that device.

After looking at the issue I decided to go ahead with this fairly large refactoring that changes a few things:
* Remove the concept of preferred ratios, the closest ratio to the ratio of the TextureView will be selected, if there is a size that is big enough.
* Remove the ability to adjust view bounds. The original library will allow you to set `wrap_content` in your `CameraView` and this will automatically resize to the size of the preview. We don't use this in the Monzo app and the code was really buggy anyway so it was removed in this PR.
* When the ratio of the CameraView doesn't match any available preview sizes, we chose the closes one and then we apply some transformations to the surface to ensure that the preview is not squashed or moved towards one side. This means that the resulting output could have extra content that you are not seeing in the preview.
* Adds Timber for logging

Tested on Pixel 2, Nexus 5X successfully. 